### PR TITLE
Also supporting v2 of rest-client

### DIFF
--- a/eway_rapid.gemspec
+++ b/eway_rapid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '>= 1.8.0, < 3'
   spec.add_dependency 'json', '~> 1.8.3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
Had issues with bundler earlier because of a conflict on mime-types. Basically mail (from actionmailer v4.2.7.1) and rest-client had incompatible requirements for mime-types. rest-client 2.0 is now out and seemed to work fine in my local testing.
