### PR TITLE
Allow secured_card_data to be sent to eWay

### DIFF
--- a/lib/eway_rapid/constants.rb
+++ b/lib/eway_rapid/constants.rb
@@ -75,6 +75,7 @@ module EwayRapid
     CHECKOUT_PAYMENT = 'CheckoutPayment'
     CHECKOUT_URL = 'CheckoutUrl'
     TRANSACTION_TYPE = 'TransactionType'
+    SECURED_CARD_DATA = 'SecuredCardData'
     PARTNER_ID = 'PartnerID'
     TRANSACTIONS = 'Transactions'
     ERRORS_CAPITALIZED = 'Errors'

--- a/lib/eway_rapid/entities/direct_payment_request.rb
+++ b/lib/eway_rapid/entities/direct_payment_request.rb
@@ -7,6 +7,7 @@ module EwayRapid
     attr_accessor :payment
     attr_accessor :method
     attr_accessor :transaction_type
+    attr_accessor :secured_card_data
     attr_accessor :customer_ip
     attr_accessor :device_id
     attr_accessor :partner_id
@@ -20,6 +21,7 @@ module EwayRapid
        Constants::PAYMENT            => InternalModels::Payment.to_hash(payment),
        Constants::METHOD             => method,
        Constants::TRANSACTION_TYPE   => transaction_type,
+       Constants::SECURED_CARD_DATA  => secured_card_data,
        Constants::CUSTOMER_DEVICE_IP => customer_ip,
        Constants::DEVICE_ID          => device_id,
        Constants::PARTNER_ID         => partner_id,

--- a/lib/eway_rapid/message/convert/request/transaction_to_direct_payment.rb
+++ b/lib/eway_rapid/message/convert/request/transaction_to_direct_payment.rb
@@ -30,6 +30,7 @@ module EwayRapid
             request.device_id = input.device_id
             request.partner_id = input.partner_id
             request.transaction_type = input.transaction_type || ''
+            request.secured_card_data = input.secured_card_data
             request.method = if input.capture
                                Enums::RequestMethod::PROCESS_PAYMENT
                              else

--- a/test/eway_rapid/message/convert/request/transaction_to_direct_payment_converter_test.rb
+++ b/test/eway_rapid/message/convert/request/transaction_to_direct_payment_converter_test.rb
@@ -17,6 +17,7 @@ module EwayRapid
             @input.customer = customer
             @input.payment_details = payment_details
             @input.transaction_type = Enums::TransactionType::PURCHASE
+            @input.secured_card_data = ObjectCreator.create_secured_card_data
             @input.capture = true
           end
 
@@ -26,6 +27,7 @@ module EwayRapid
             assert_equal('John', request.customer.first_name)
             assert_equal('Level 5', request.customer.street1)
             assert_equal('12',request.customer.card_details.expiry_month)
+            assert_equal(@input.secured_card_data,request.secured_card_data)
             assert_equal(Enums::TransactionType::PURCHASE,request.transaction_type)
           end
         end

--- a/test/eway_rapid/object/create/object_creator.rb
+++ b/test/eway_rapid/object/create/object_creator.rb
@@ -63,6 +63,10 @@ module EwayRapid
       card_details
     end
 
+    def self.create_secured_card_data
+      'foo'
+    end
+
     def self.create_internal_customer
       customer = InternalModels::Customer.new
       customer.token_customer_id = '123456789'


### PR DESCRIPTION
This PR allows `secured_card_data` added to a `Transaction` model to be sent through to eWay by:

1) Ensuring that `secured_card_data` is kept when converting a transaction for direct payment
2) Adding a `secured_card_data` attr to `DirectPaymentRequest`
3) Adding `SecuredCardData` to the `to_json` method of the above class so that the paramater is included as part of the payload