### PR TITLE
Bump json to fix CVE-2020-10663.

### DIFF
--- a/eway_rapid.gemspec
+++ b/eway_rapid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'json', '~> 2.1.0'
+  spec.add_dependency 'json', '~> 2.3.0'
   spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.17'


### PR DESCRIPTION
Considering there is no breaking change from json 2.1 to 2.3, I'm bumping the dependency to fix CVE-2020-10663