### PR TITLE
update json and bundler gem versions

### DIFF
--- a/eway_rapid.gemspec
+++ b/eway_rapid.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'json', '~> 2.1.0'
+  spec.add_dependency 'json', '~> 2.7'
   spec.add_dependency 'rest-client', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2.5.3'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
The dependency 'json', '~> 2.1.0' contains [methods deprecated](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) in ruby version 3, therefore making this gem incompatible with ruby version 3 and above.